### PR TITLE
回線落ち後再起動せず別の部屋に入った、部屋に復帰した時にGameLogが混ざる問題を修正。

### DIFF
--- a/SuperSimplePlus/Patches/ChatLogPatch.cs
+++ b/SuperSimplePlus/Patches/ChatLogPatch.cs
@@ -205,7 +205,7 @@ internal static class SaveChatLogPatch
     internal static string RoundGameLogFilePath { get { return _roundGameLogFilePath; } }
     private static string _roundGameLogFilePath;
 
-    private static Dictionary<int, string> GameLogDic = new();
+    private static readonly Dictionary<int, string> GameLogDic = new();
     private static StringBuilder NowGameLog = new();
 
     internal static int GameCount = 0;
@@ -309,9 +309,11 @@ internal static class SaveChatLogPatch
         string useLogString = NowGameLog.ToString();
         NowGameLog = new();
 
-        using (StreamWriter sw = new(ChatLogFilePath, true)) await sw.WriteLineAsync(useLogString);
+        if (GameLogDic.ContainsKey(GameCount)) return;
 
-        if (!GameLogDic.ContainsKey(GameCount)) GameLogDic.Add(GameCount, useLogString);
+        GameLogDic.Add(GameCount, useLogString);
+        using StreamWriter sw = new(ChatLogFilePath, true);
+        await sw.WriteLineAsync(useLogString);
     }
     internal static (string log, bool success) GetGameLogDic(int count) =>
         GameLogDic.ContainsKey(count) ? (GameLogDic[count], true) : (Format(ModTranslation.GetString("GetGameLogDicError"), count), false);

--- a/SuperSimplePlus/Patches/GameStartManagerPatch.cs
+++ b/SuperSimplePlus/Patches/GameStartManagerPatch.cs
@@ -87,5 +87,6 @@ public class VariableManager
         ResultsOfTheVoteCount = new();
         Helpers.IdControlDic = new();
         Helpers.CDToNameDic = new();
+        SaveChatLogPatch.AddGameLog();
     }
 }


### PR DESCRIPTION
ClearAndRerodeでも書き込み&Stringbuilderのリセットを行うように変更。
2度書き込みをする事を防ぐ為、辞書にその回が登録済みならreturnし辞書への追加とLog書き込みを行わないようにしている。