### PR TITLE
Hotfix/20240904

### DIFF
--- a/SuperSimplePlus/Patches/ChatLogPatch.cs
+++ b/SuperSimplePlus/Patches/ChatLogPatch.cs
@@ -341,7 +341,7 @@ class ChatLogHarmonyPatch
 
         // 死体通報
         [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.ReportDeadBody)), HarmonyPostfix]
-        static void ReportDeadBodyPostfix(PlayerControl __instance, [HarmonyArgument(0)] GameData.PlayerInfo target) => ReportDeadBodySystemLog(__instance, target);
+        static void ReportDeadBodyPostfix(PlayerControl __instance, [HarmonyArgument(0)] NetworkedPlayerInfo target) => ReportDeadBodySystemLog(__instance, target);
 
         // 投票感知&記載(Hostのみ)
         [HarmonyPatch(typeof(MeetingHud), nameof(MeetingHud.CastVote)), HarmonyPostfix]
@@ -353,11 +353,11 @@ class ChatLogHarmonyPatch
 
         // 会議終了(airship以外)
         [HarmonyPatch(typeof(ExileController), nameof(ExileController.WrapUp)), HarmonyPostfix]
-        static void MeetingEndPostfix(ExileController __instance) => DescribeMeetingEndSystemLog(__instance.exiled);
+        static void MeetingEndPostfix(ExileController __instance) => DescribeMeetingEndSystemLog(__instance.initData?.networkedPlayer);
 
         // 会議終了(airship)
         [HarmonyPatch(typeof(AirshipExileController), nameof(AirshipExileController.WrapUpAndSpawn)), HarmonyPostfix]
-        static void AirshipMeetingEndPostfix(ExileController __instance) => DescribeMeetingEndSystemLog(__instance.exiled);
+        static void AirshipMeetingEndPostfix(ExileController __instance) => DescribeMeetingEndSystemLog(__instance.initData?.networkedPlayer);
 
         // キル発生時
         [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.MurderPlayer)), HarmonyPostfix]
@@ -451,7 +451,7 @@ class SystemLogMethodManager
     }
 
     // 死体通報
-    internal static void ReportDeadBodySystemLog(PlayerControl convener, GameData.PlayerInfo target)
+    internal static void ReportDeadBodySystemLog(PlayerControl convener, NetworkedPlayerInfo target)
     {
         if (!SSPPlugin.ChatLog.Value) return;
 
@@ -476,7 +476,7 @@ class SystemLogMethodManager
     internal static void OpenVoteSystemLog(string openVoteMessage) => SaveSystemLog(GetSystemMessageLog(openVoteMessage));
 
     // 会議終了
-    internal static void DescribeMeetingEndSystemLog(GameData.PlayerInfo exiled)
+    internal static void DescribeMeetingEndSystemLog(NetworkedPlayerInfo exiled)
     {
         if (!SSPPlugin.ChatLog.Value) return;
 

--- a/SuperSimplePlus/Patches/ChatLogPatch.cs
+++ b/SuperSimplePlus/Patches/ChatLogPatch.cs
@@ -119,8 +119,7 @@ class SendChatPatch
         if (!SSPPlugin.ChatLog.Value) return;
 
         string date = DateTime.Now.ToString("[HH:mm:ss]");
-        string name = PlayerControl.LocalPlayer.GetClient().PlayerName;
-        string outChatMemo = processingRequired ? $"{date} {name} : {chatMemo}" : $"{date} {chatMemo}";
+        string outChatMemo = processingRequired ? $"{date} {PlayerControl.LocalPlayer?.GetClient().PlayerName} : {chatMemo}" : $"{date} {chatMemo}";
 
         if (ResetedMemo)
             File.AppendAllText(LogMemoFilePath, $"{outChatMemo}" + Environment.NewLine);

--- a/SuperSimplePlus/Patches/PingTrackerPatch.cs
+++ b/SuperSimplePlus/Patches/PingTrackerPatch.cs
@@ -8,13 +8,11 @@ public class PingTrackerPatch
     {
         public static void Postfix(PingTracker __instance)
         {
-            __instance.text.alignment = TMPro.TextAlignmentOptions.TopRight;
             var bc = $"{ThisAssembly.Git.Branch}({ThisAssembly.Git.Commit})";
             __instance.text.text =
                 ThisAssembly.Git.Branch == "main" ?
-                    $"{SSPPlugin.ColoredModName} ver.{SSPPlugin.Version}\n{__instance.text.text}" :
-                    $"{SSPPlugin.ColoredModName} ver.{SSPPlugin.Version}\n{bc}\n{__instance.text.text}";
-            __instance.gameObject.GetComponent<AspectPosition>().DistanceFromEdge = new Vector3(1.2f, 0.1f, 0.5f);
+                    $"{__instance.text.text}\n{SSPPlugin.ColoredModName} ver.{SSPPlugin.Version}" :
+                    $"{__instance.text.text}\n{SSPPlugin.ColoredModName} ver.{SSPPlugin.Version}\n{bc}";
         }
     }
 }

--- a/SuperSimplePlus/Patches/PingTrackerPatch.cs
+++ b/SuperSimplePlus/Patches/PingTrackerPatch.cs
@@ -12,9 +12,7 @@ public class PingTrackerPatch
             __instance.text.text =
                 AmongUsClient.Instance.GameState == AmongUsClient.GameStates.Started
                     ? $"{__instance.text.text}<size=67%><line-height=55%>\n<pos=25%>{SSPPlugin.ColoredModName} ver.{SSPPlugin.Version}{(ThisAssembly.Git.Branch == "main" ? "" : " (β)")}</size></line-height>"
-                    : ThisAssembly.Git.Branch == "main" ?
-                        $"{__instance.text.text}\n{SSPPlugin.ColoredModName} ver.{SSPPlugin.Version}" :
-                        $"{__instance.text.text}\n{SSPPlugin.ColoredModName} ver.{SSPPlugin.Version}\n{bc}";
+                    : $"{__instance.text.text}\n<pos=25%>{SSPPlugin.ColoredModName} ver.{SSPPlugin.Version}</pos>{(ThisAssembly.Git.Branch == "main" ? "" : $"\n<pos=25%>{bc}</pos>")}";
         }
     }
 }

--- a/SuperSimplePlus/Patches/PingTrackerPatch.cs
+++ b/SuperSimplePlus/Patches/PingTrackerPatch.cs
@@ -10,9 +10,11 @@ public class PingTrackerPatch
         {
             var bc = $"{ThisAssembly.Git.Branch}({ThisAssembly.Git.Commit})";
             __instance.text.text =
-                ThisAssembly.Git.Branch == "main" ?
-                    $"{__instance.text.text}\n{SSPPlugin.ColoredModName} ver.{SSPPlugin.Version}" :
-                    $"{__instance.text.text}\n{SSPPlugin.ColoredModName} ver.{SSPPlugin.Version}\n{bc}";
+                AmongUsClient.Instance.GameState == AmongUsClient.GameStates.Started
+                    ? $"{__instance.text.text}<size=67%><line-height=55%>\n<pos=25%>{SSPPlugin.ColoredModName} ver.{SSPPlugin.Version}{(ThisAssembly.Git.Branch == "main" ? "" : " (β)")}</size></line-height>"
+                    : ThisAssembly.Git.Branch == "main" ?
+                        $"{__instance.text.text}\n{SSPPlugin.ColoredModName} ver.{SSPPlugin.Version}" :
+                        $"{__instance.text.text}\n{SSPPlugin.ColoredModName} ver.{SSPPlugin.Version}\n{bc}";
         }
     }
 }


### PR DESCRIPTION
# [変更内容 詳細]
- Mod名の表示位置等を調整した。
  - ping位置が右上から中央寄りに移動していた物を, 右上に戻していたコードを削除した。
  - ゲーム中のMod名表記の文字サイズを小さくした。
  - ベータ版使用時, ゲーム中はブランチ名ではなく "(β)"と表示するように変更した

# [修正内容詳細]
- 2024.6.18に対応した
  - GameData.PlayerInfo を NetworkedPlayerInfo に修正した。<br><br>
- Mod共存化において, 共存先のModのリザルトが正常に表示されない(バニラリザルトになってしまう)問題を修正した。
  - EndGameManager.SetEverythingUpにおいて, LocalPlayerがnullなのにも関わらず, そこからClientDateを取得していた事により発生していたエラーが原因だった。
  - AmongUs_ChatMemo.logへの書き込み時, 内容がシステムログの場合, "発言者の名前"を取得しないように変更する事で修正した。